### PR TITLE
Fix enable_captcha option

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,6 +40,7 @@ import setup_pf
 
 # When no action or repo is specified, redirect to this action.
 HOME_ACTION = '/chennai'
+ENABLE_CAPTCHA = False
 
 # Map of URL actions to Python module and class names.
 # TODO(kpy): Remove the need for this configuration information, either by
@@ -331,7 +332,7 @@ def setup_env(request):
     # Enables features which require JavaScript.
     env.enable_javascript = True
     # Enables operations which requires Captcha.
-    env.enable_captcha = False
+    env.enable_captcha = ENABLE_CAPTCHA
     # Enables photo upload.
     env.enable_photo_upload = True
     # Enables to flag/unflag notes as spam, and to reveal spam notes.
@@ -359,7 +360,7 @@ def setup_env(request):
         env.enable_javascript = False
         # Disables operations which requires Captcha because Captcha requires
         # JavaScript.
-        env.enable_captcha = False
+        env.enable_captcha = ENABLE_CAPTCHA 
         # Uploading is often not supported in feature phones.
         env.enable_photo_upload = False
         # Disables spam operations because it requires JavaScript and

--- a/app/main.py
+++ b/app/main.py
@@ -331,7 +331,7 @@ def setup_env(request):
     # Enables features which require JavaScript.
     env.enable_javascript = True
     # Enables operations which requires Captcha.
-    env.enable_captcha = True
+    env.enable_captcha = False
     # Enables photo upload.
     env.enable_photo_upload = True
     # Enables to flag/unflag notes as spam, and to reveal spam notes.

--- a/app/resources/subscribe_captcha.html.template
+++ b/app/resources/subscribe_captcha.html.template
@@ -44,7 +44,7 @@
     </div>
     <br/><br/>
     {% if env.enable_captcha == True %}
-    {{captcha_html|safe}i}
+       {{captcha_html|safe}}
     {% endif %}
     <br/><br/>
     <div>

--- a/app/resources/subscribe_captcha.html.template
+++ b/app/resources/subscribe_captcha.html.template
@@ -43,7 +43,7 @@
       {{message}}
     </div>
     <br/><br/>
-    {% if env.enable_captcha == True %}
+    {% if env.enable_captcha %}
        {{captcha_html|safe}}
     {% endif %}
     <br/><br/>

--- a/app/subscribe.py
+++ b/app/subscribe.py
@@ -171,8 +171,7 @@ class Handler(BaseHandler):
                                    self.__get_person_record_link_html(person))
 
         # Check the captcha
-        captcha_enabled = os.environ.get('enable_captcha', False)
-        if captcha_enabled:
+        if self.env.enable_captcha:
             captcha_response = self.get_captcha_response()
             if not captcha_response.is_valid and not self.env.test_mode:
                 # Captcha is incorrect


### PR DESCRIPTION
Prior to this commit, when subscribing to a person's updates,
captcha box is opened. Given that it is an experimental feature
in people finder project and our team wanted to disable it,
this patch takes care of disabling it.
Also, captcha was tightly coupled with subcription.
This patch decouples captcha and subsription functionality.
